### PR TITLE
Add LayerZero messenger integration

### DIFF
--- a/contracts/LevelerMessenger.sol
+++ b/contracts/LevelerMessenger.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./AlturaNFTLeveler.sol";
+
+/// @notice Minimal interface for a LayerZero-style receiver
+interface ILayerZeroReceiver {
+    function lzReceive(
+        uint16 _srcChainId,
+        bytes calldata _srcAddress,
+        uint64 _nonce,
+        bytes calldata _payload
+    ) external;
+}
+
+/// @notice Minimal interface for a LayerZero endpoint used for authentication
+interface ILayerZeroEndpoint {
+    function send(
+        uint16 _dstChainId,
+        bytes calldata _destination,
+        bytes calldata _payload,
+        address payable _refundAddress,
+        address _zroPaymentAddress,
+        bytes calldata _adapterParams
+    ) external payable;
+}
+
+/// @title LevelerMessenger
+/// @notice Receives cross-chain messages and forwards them to a Leveler contract
+contract LevelerMessenger is ILayerZeroReceiver {
+    ILayerZeroEndpoint public immutable endpoint;
+    AlturaNFTLevelerV3 public immutable leveler;
+
+    constructor(address _endpoint, address _leveler) {
+        require(_endpoint != address(0), "invalid endpoint");
+        require(_leveler != address(0), "invalid leveler");
+        endpoint = ILayerZeroEndpoint(_endpoint);
+        leveler = AlturaNFTLevelerV3(_leveler);
+    }
+
+    /// @notice Called by the LayerZero endpoint to deliver a message
+    function lzReceive(
+        uint16, /*_srcChainId*/
+        bytes calldata, /*_srcAddress*/
+        uint64, /*_nonce*/
+        bytes calldata _payload
+    ) external override {
+        require(msg.sender == address(endpoint), "unauthorized");
+        (address user, uint256 tokenId, uint8 rarity) = abi.decode(
+            _payload,
+            (address, uint256, uint8)
+        );
+        leveler.levelUp(user, tokenId, rarity);
+    }
+}
+

--- a/contracts/MockLayerZeroEndpoint.sol
+++ b/contracts/MockLayerZeroEndpoint.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./LevelerMessenger.sol";
+
+/// @notice Simple mock endpoint that directly calls lzReceive on the target
+contract MockLayerZeroEndpoint {
+    function send(address receiver, bytes calldata payload) external {
+        ILayerZeroReceiver(receiver).lzReceive(0, bytes(""), 0, payload);
+    }
+}
+

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -3,6 +3,7 @@ import "@nomicfoundation/hardhat-toolbox";
 import "hardhat-contract-sizer";
 import "@nomicfoundation/hardhat-toolbox";
 import "@openzeppelin/hardhat-upgrades";
+import "@layerzerolabs/hardhat-verify";
 import * as dotenv from "dotenv";
 
 dotenv.config();
@@ -40,6 +41,13 @@ const config: HardhatUserConfig = {
         process.env.AMOY_USERA_PRIVATE_KEY!,
         process.env.AMOY_USERB_PRIVATE_KEY!
       ].filter((x) => x !== undefined),
+      gas: "auto",
+      gasPrice: "auto",
+    },
+    xdcTestnet: {
+      url: process.env.XDC_RPC_URL || "",
+      chainId: 51,
+      accounts: [process.env.XDC_DEPLOYER_PRIVATE_KEY!].filter((x) => x !== undefined),
       gas: "auto",
       gasPrice: "auto",
     },

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "dotenv": "^16.5.0",
     "hardhat-contract-sizer": "^2.10.0",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "@layerzerolabs/hardhat-verify": "^0.3.0"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^5.3.0",
-    "ethers": "^6.13.2"
+    "ethers": "^6.13.2",
+    "@layerzerolabs/lz-v2-evm": "^1.0.0"
   }
 }

--- a/scripts/deploy-messenger.ts
+++ b/scripts/deploy-messenger.ts
@@ -1,0 +1,27 @@
+import { ethers } from "hardhat";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  console.log("Deploying LevelerMessenger with:", deployer.address);
+
+  const LEVELER = process.env.LEVELER_ADDRESS;
+  const ENDPOINT = process.env.LZ_ENDPOINT;
+  if (!LEVELER || !ENDPOINT) {
+    throw new Error("LEVELER_ADDRESS and LZ_ENDPOINT must be set in env");
+  }
+
+  const Messenger = await ethers.getContractFactory("LevelerMessenger");
+  const messenger = await Messenger.deploy(ENDPOINT, LEVELER);
+  await messenger.waitForDeployment();
+
+  console.log("LevelerMessenger deployed at:", await messenger.getAddress());
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+

--- a/scripts/deploy-upgradeable-leveler.ts
+++ b/scripts/deploy-upgradeable-leveler.ts
@@ -32,6 +32,19 @@ async function main() {
 
   console.log("AlturaNFTLeveler (proxy) deployed at:", await levelerProxy.getAddress());
 
+  // Deploy the messenger linked to this leveler
+  const ENDPOINT = process.env.LZ_ENDPOINT;
+  if (!ENDPOINT) throw new Error("LZ_ENDPOINT env var not set");
+  const Messenger = await ethers.getContractFactory("LevelerMessenger");
+  const messenger = await Messenger.deploy(ENDPOINT, await levelerProxy.getAddress());
+  await messenger.waitForDeployment();
+  console.log("LevelerMessenger deployed at:", await messenger.getAddress());
+
+  // Grant messenger authorization to call levelUp
+  const authTx = await levelerProxy.setAuthorized(await messenger.getAddress());
+  await authTx.wait();
+  console.log("Messenger authorized on leveler");
+
   // 7) (Optional) Output the implementation address for record‐keeping:
   const impl = await upgrades.erc1967.getImplementationAddress(await levelerProxy.getAddress());
   console.log("Implementation address:", impl);

--- a/test/LevelerMessenger.test.ts
+++ b/test/LevelerMessenger.test.ts
@@ -1,0 +1,52 @@
+import { expect } from "chai";
+import { ethers, upgrades } from "hardhat";
+
+describe("LevelerMessenger", function () {
+  it("forwards cross-chain messages to Leveler", async function () {
+    const [owner, user, authorized] = await ethers.getSigners();
+
+    // Deploy ERC1155
+    const NFT = await ethers.getContractFactory("MyToken");
+    const nft = await NFT.deploy(owner.address);
+    await nft.mint(user.address, 1, 1, "0x");
+
+    // Deploy ERC20
+    const Token = await ethers.getContractFactory("TestToken");
+    const token = await Token.deploy(owner.address);
+    await token.mint(user.address, ethers.parseUnits("100", 18));
+
+    // Deploy Leveler V3
+    const Leveler = await ethers.getContractFactory("AlturaNFTLevelerV3");
+    const leveler = await upgrades.deployProxy(
+      Leveler,
+      [await nft.getAddress(), await token.getAddress(), ethers.parseUnits("1", 18), authorized.address],
+      { initializer: "initialize" }
+    );
+    await leveler.waitForDeployment();
+    await leveler.initializeV3(10);
+
+    // Deploy mock endpoint and messenger
+    const Endpoint = await ethers.getContractFactory("MockLayerZeroEndpoint");
+    const endpoint = await Endpoint.deploy();
+
+    const Messenger = await ethers.getContractFactory("LevelerMessenger");
+    const messenger = await Messenger.deploy(await endpoint.getAddress(), await leveler.getAddress());
+
+    // Make messenger the authorized caller
+    await leveler.connect(owner).setAuthorized(await messenger.getAddress());
+
+    // Approve fee payment
+    await token.connect(user).approve(await leveler.getAddress(), ethers.parseUnits("10", 18));
+
+    const payload = ethers.AbiCoder.defaultAbiCoder().encode([
+      "address",
+      "uint256",
+      "uint8",
+    ], [user.address, 1, 1]);
+
+    await endpoint.send(await messenger.getAddress(), payload);
+
+    expect(await leveler.getLevel(1)).to.equal(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- integrate LayerZero Hardhat plugin and libraries
- add LayerZero messenger contract to forward cross-chain messages
- provide a mock endpoint for tests
- deploy messenger in `deploy-upgradeable-leveler.ts`
- add standalone deployment script for messenger
- expand Hardhat config with plugin and XDC network
- add test covering cross-chain message flow

## Testing
- `npx hardhat test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684c141e3d08832c82e6d861e4b084ec